### PR TITLE
Fix CI: iOS Room KSP stubs in generated dir

### DIFF
--- a/shared/build.gradle.kts
+++ b/shared/build.gradle.kts
@@ -1,5 +1,4 @@
 import dev.detekt.gradle.Detekt
-import org.gradle.nativeplatform.platform.internal.DefaultNativePlatform
 import org.jetbrains.kotlin.gradle.plugin.mpp.NativeBuildType
 
 plugins {
@@ -23,16 +22,6 @@ tasks.register("detektAll") {
 
 detekt {
     config.setFrom(file("config/detekt/detekt.yml"))
-}
-
-tasks.configureEach {
-    if (name == "compileKotlinIosArm64" || name == "compileKotlinIosSimulatorArm64") {
-        val isMac = DefaultNativePlatform.getCurrentOperatingSystem().isMacOsX
-        if (!isMac) {
-            logger.warn("⚠️ Unsupported Operating System\n$name is fully supported on MacOS machines only. This task will be skipped.")
-        }
-        onlyIf { isMac }
-    }
 }
 
 object AppInfo {

--- a/shared/build/generated/ksp/iosArm64/iosArm64Main/kotlin/io/github/kroune/cumobile/data/local/db/AppDatabaseConstructor.kt
+++ b/shared/build/generated/ksp/iosArm64/iosArm64Main/kotlin/io/github/kroune/cumobile/data/local/db/AppDatabaseConstructor.kt
@@ -1,0 +1,8 @@
+package io.github.kroune.cumobile.`data`.local.db
+
+import androidx.room.RoomDatabaseConstructor
+
+public actual object AppDatabaseConstructor : RoomDatabaseConstructor<AppDatabase> {
+    actual override fun initialize(): AppDatabase =
+        error("Room KSP stub — run iOS build on macOS for real implementation")
+}

--- a/shared/build/generated/ksp/iosSimulatorArm64/iosSimulatorArm64Main/kotlin/io/github/kroune/cumobile/data/local/db/AppDatabaseConstructor.kt
+++ b/shared/build/generated/ksp/iosSimulatorArm64/iosSimulatorArm64Main/kotlin/io/github/kroune/cumobile/data/local/db/AppDatabaseConstructor.kt
@@ -1,0 +1,8 @@
+package io.github.kroune.cumobile.`data`.local.db
+
+import androidx.room.RoomDatabaseConstructor
+
+public actual object AppDatabaseConstructor : RoomDatabaseConstructor<AppDatabase> {
+    actual override fun initialize(): AppDatabase =
+        error("Room KSP stub — run iOS build on macOS for real implementation")
+}

--- a/shared/src/commonMain/kotlin/io/github/kroune/cumobile/data/local/db/AppDatabase.kt
+++ b/shared/src/commonMain/kotlin/io/github/kroune/cumobile/data/local/db/AppDatabase.kt
@@ -15,8 +15,8 @@ abstract class AppDatabase : RoomDatabase() {
     abstract fun fileRenameRuleDao(): FileRenameRuleDao
 }
 
-// Room compiler generates the actual implementation on Mac builds.
-// Manual actual stubs exist in androidMain/iosMain for Linux CI compatibility.
+// Room KSP generates the actual implementation.
+// iOS stubs are checked into build/generated/ksp/ios*/; KSP overwrites them on macOS.
 expect object AppDatabaseConstructor : RoomDatabaseConstructor<AppDatabase> {
     override fun initialize(): AppDatabase
 }


### PR DESCRIPTION
## Summary
- Check in Room KSP stubs for iOS targets directly into `build/generated/ksp/ios*/` directories
- On macOS, KSP overwrites them with real implementations; on Linux they remain as-is
- Remove the `compileKotlinIos*` skip workaround from `build.gradle.kts`

## Test plan
- [ ] ktlintCheck passes on Linux (verified locally)
- [ ] Unit tests pass on Linux CI
- [ ] iOS build passes on macOS CI (KSP regenerates real actual)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Simplified build configuration for improved maintainability.
  * Updated internal build documentation for database generation process.

**Note:** These are internal infrastructure improvements with no user-visible changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->