### PR TITLE
Fix profile: avatar display + copy-to-clipboard

### DIFF
--- a/shared/src/commonMain/kotlin/io/github/kroune/cumobile/presentation/common/TopBar.kt
+++ b/shared/src/commonMain/kotlin/io/github/kroune/cumobile/presentation/common/TopBar.kt
@@ -1,5 +1,6 @@
 package io.github.kroune.cumobile.presentation.common
 
+import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
@@ -7,6 +8,7 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
@@ -17,6 +19,8 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.ImageBitmap
+import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -38,6 +42,7 @@ import androidx.compose.ui.unit.sp
 fun TopBar(
     title: String,
     profileInitials: String,
+    avatarBitmap: ImageBitmap? = null,
     lateDaysBalance: Int?,
     onNotificationsClick: () -> Unit,
     onProfileClick: () -> Unit,
@@ -87,6 +92,7 @@ fun TopBar(
         // Profile avatar circle
         AvatarCircle(
             initials = profileInitials,
+            avatarBitmap = avatarBitmap,
             onClick = onProfileClick,
         )
     }
@@ -101,6 +107,7 @@ fun TopBar(
 @Composable
 private fun AvatarCircle(
     initials: String,
+    avatarBitmap: ImageBitmap?,
     onClick: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
@@ -113,12 +120,21 @@ private fun AvatarCircle(
             .clickable(onClick = onClick),
         contentAlignment = Alignment.Center,
     ) {
-        Text(
-            text = initials.ifEmpty { "?" },
-            color = AppTheme.colors.accent,
-            fontSize = 14.sp,
-            fontWeight = FontWeight.Bold,
-        )
+        if (avatarBitmap != null) {
+            Image(
+                bitmap = avatarBitmap,
+                contentDescription = "Аватар",
+                contentScale = ContentScale.Crop,
+                modifier = Modifier.fillMaxSize(),
+            )
+        } else {
+            Text(
+                text = initials.ifEmpty { "?" },
+                color = AppTheme.colors.accent,
+                fontSize = 14.sp,
+                fontWeight = FontWeight.Bold,
+            )
+        }
     }
 }
 

--- a/shared/src/commonMain/kotlin/io/github/kroune/cumobile/presentation/home/DefaultHomeComponent.kt
+++ b/shared/src/commonMain/kotlin/io/github/kroune/cumobile/presentation/home/DefaultHomeComponent.kt
@@ -7,11 +7,14 @@ import com.arkivanov.essenty.lifecycle.coroutines.coroutineScope
 import io.github.kroune.cumobile.data.model.StudentTask
 import io.github.kroune.cumobile.data.model.TaskState
 import io.github.kroune.cumobile.presentation.common.DateTimeProvider
+import io.github.kroune.cumobile.presentation.common.decodeImageBitmap
 import io.github.oshai.kotlinlogging.KotlinLogging
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import kotlin.coroutines.CoroutineContext
 
 private val logger = KotlinLogging.logger {}
 
@@ -26,6 +29,7 @@ private const val MillisPerDay = 86_400_000L
 class DefaultHomeComponent(
     componentContext: ComponentContext,
     deps: HomeDependencies,
+    private val defaultDispatcher: CoroutineContext = Dispatchers.Default,
     private val onOpenTask: (StudentTask) -> Unit,
     private val onOpenCourse: (String) -> Unit,
     private val onOpenProfile: () -> Unit = {},
@@ -111,11 +115,16 @@ class DefaultHomeComponent(
                 val courses = courseRepository.fetchCourses()
                 val initials = loadProfileInitials()
                 val lmsProfile = profileRepository.fetchLmsProfile()
+                val avatar = profileRepository.fetchAvatar()
+                val bitmap = withContext(defaultDispatcher) {
+                    avatar?.let { decodeImageBitmap(it) }
+                }
 
                 _state.value = _state.value.copy(
                     tasks = tasks.orEmpty(),
                     courses = courses.orEmpty(),
                     profileInitials = initials,
+                    avatarBitmap = bitmap,
                     lateDaysBalance = lmsProfile?.lateDaysBalance,
                     isLoading = false,
                     error = if (tasks == null && courses == null) {

--- a/shared/src/commonMain/kotlin/io/github/kroune/cumobile/presentation/home/HomeComponent.kt
+++ b/shared/src/commonMain/kotlin/io/github/kroune/cumobile/presentation/home/HomeComponent.kt
@@ -1,5 +1,6 @@
 package io.github.kroune.cumobile.presentation.home
 
+import androidx.compose.ui.graphics.ImageBitmap
 import com.arkivanov.decompose.value.Value
 import io.github.kroune.cumobile.data.model.ClassData
 import io.github.kroune.cumobile.data.model.Course
@@ -28,6 +29,7 @@ interface HomeComponent {
         val isScheduleLoading: Boolean = false,
         val scheduleError: String? = null,
         val profileInitials: String = "",
+        val avatarBitmap: ImageBitmap? = null,
         val lateDaysBalance: Int? = null,
         val isLoading: Boolean = true,
         val error: String? = null,
@@ -47,6 +49,37 @@ interface HomeComponent {
         /** Active (non-archived) courses. */
         val activeCourses: List<Course>
             get() = courses.filter { !it.isArchived }
+
+        override fun equals(other: Any?): Boolean {
+            if (this === other) return true
+            if (other !is State) return false
+            return tasks == other.tasks &&
+                courses == other.courses &&
+                classes == other.classes &&
+                selectedDateMillis == other.selectedDateMillis &&
+                isScheduleLoading == other.isScheduleLoading &&
+                scheduleError == other.scheduleError &&
+                profileInitials == other.profileInitials &&
+                avatarBitmap === other.avatarBitmap &&
+                lateDaysBalance == other.lateDaysBalance &&
+                isLoading == other.isLoading &&
+                error == other.error
+        }
+
+        override fun hashCode(): Int {
+            var result = tasks.hashCode()
+            result = 31 * result + courses.hashCode()
+            result = 31 * result + classes.hashCode()
+            result = 31 * result + selectedDateMillis.hashCode()
+            result = 31 * result + isScheduleLoading.hashCode()
+            result = 31 * result + (scheduleError?.hashCode() ?: 0)
+            result = 31 * result + profileInitials.hashCode()
+            result = 31 * result + (avatarBitmap?.hashCode() ?: 0)
+            result = 31 * result + (lateDaysBalance?.hashCode() ?: 0)
+            result = 31 * result + isLoading.hashCode()
+            result = 31 * result + (error?.hashCode() ?: 0)
+            return result
+        }
     }
 
     sealed interface Intent {

--- a/shared/src/commonMain/kotlin/io/github/kroune/cumobile/presentation/main/MainScreen.kt
+++ b/shared/src/commonMain/kotlin/io/github/kroune/cumobile/presentation/main/MainScreen.kt
@@ -86,6 +86,7 @@ fun MainScreen(component: MainComponent) {
             TopBar(
                 title = TAB_LABELS[selectedIndex],
                 profileInitials = homeState?.profileInitials.orEmpty(),
+                avatarBitmap = homeState?.avatarBitmap,
                 lateDaysBalance = homeState?.lateDaysBalance,
                 onNotificationsClick = { component.navigateToNotifications() },
                 onProfileClick = { component.navigateToProfile() },

--- a/shared/src/commonMain/kotlin/io/github/kroune/cumobile/presentation/profile/DefaultProfileComponent.kt
+++ b/shared/src/commonMain/kotlin/io/github/kroune/cumobile/presentation/profile/DefaultProfileComponent.kt
@@ -6,6 +6,7 @@ import com.arkivanov.decompose.value.Value
 import com.arkivanov.essenty.lifecycle.coroutines.coroutineScope
 import io.github.kroune.cumobile.data.model.PickedFile
 import io.github.kroune.cumobile.domain.repository.ProfileRepository
+import io.github.kroune.cumobile.presentation.common.decodeImageBitmap
 import io.github.oshai.kotlinlogging.KotlinLogging
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
@@ -13,6 +14,8 @@ import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import kotlin.coroutines.CoroutineContext
 
 private val logger = KotlinLogging.logger {}
 
@@ -25,6 +28,7 @@ private val logger = KotlinLogging.logger {}
 class DefaultProfileComponent(
     componentContext: ComponentContext,
     private val profileRepository: ProfileRepository,
+    private val defaultDispatcher: CoroutineContext = Dispatchers.Default,
     private val onBack: () -> Unit,
     private val onLogout: () -> Unit,
 ) : ProfileComponent,
@@ -57,11 +61,15 @@ class DefaultProfileComponent(
             val profile = profileRepository.fetchProfile()
             val lmsProfile = profileRepository.fetchLmsProfile()
             val avatar = profileRepository.fetchAvatar()
+            val bitmap = withContext(defaultDispatcher) {
+                avatar?.let { decodeImageBitmap(it) }
+            }
             if (profile != null) {
                 _state.value = _state.value.copy(
                     profile = profile,
                     lmsProfile = lmsProfile,
                     avatarBytes = avatar,
+                    avatarBitmap = bitmap,
                     isLoading = false,
                 )
             } else {
@@ -79,8 +87,12 @@ class DefaultProfileComponent(
             val success = profileRepository.uploadAvatar(file.bytes, file.contentType)
             if (success) {
                 val avatar = profileRepository.fetchAvatar()
+                val bitmap = withContext(defaultDispatcher) {
+                    avatar?.let { decodeImageBitmap(it) }
+                }
                 _state.value = _state.value.copy(
                     avatarBytes = avatar,
+                    avatarBitmap = bitmap,
                     isUploadingAvatar = false,
                 )
             } else {
@@ -100,6 +112,7 @@ class DefaultProfileComponent(
             if (success) {
                 _state.value = _state.value.copy(
                     avatarBytes = null,
+                    avatarBitmap = null,
                     isDeletingAvatar = false,
                 )
             } else {

--- a/shared/src/commonMain/kotlin/io/github/kroune/cumobile/presentation/profile/ProfileComponent.kt
+++ b/shared/src/commonMain/kotlin/io/github/kroune/cumobile/presentation/profile/ProfileComponent.kt
@@ -1,5 +1,6 @@
 package io.github.kroune.cumobile.presentation.profile
 
+import androidx.compose.ui.graphics.ImageBitmap
 import com.arkivanov.decompose.value.Value
 import io.github.kroune.cumobile.data.model.PickedFile
 import io.github.kroune.cumobile.data.model.StudentLmsProfile
@@ -28,6 +29,7 @@ interface ProfileComponent {
         val profile: StudentProfile? = null,
         val lmsProfile: StudentLmsProfile? = null,
         val avatarBytes: ByteArray? = null,
+        val avatarBitmap: ImageBitmap? = null,
         val isLoading: Boolean = false,
         val error: String? = null,
         val isDeletingAvatar: Boolean = false,
@@ -74,6 +76,7 @@ interface ProfileComponent {
             return profile == other.profile &&
                 lmsProfile == other.lmsProfile &&
                 avatarBytes.contentEquals(other.avatarBytes) &&
+                avatarBitmap === other.avatarBitmap &&
                 isLoading == other.isLoading &&
                 error == other.error &&
                 isDeletingAvatar == other.isDeletingAvatar &&
@@ -84,6 +87,7 @@ interface ProfileComponent {
             var result = profile.hashCode()
             result = 31 * result + lmsProfile.hashCode()
             result = 31 * result + (avatarBytes?.contentHashCode() ?: 0)
+            result = 31 * result + (avatarBitmap?.hashCode() ?: 0)
             result = 31 * result + isLoading.hashCode()
             result = 31 * result + error.hashCode()
             result = 31 * result + isDeletingAvatar.hashCode()

--- a/shared/src/commonMain/kotlin/io/github/kroune/cumobile/presentation/profile/ProfileScreen.kt
+++ b/shared/src/commonMain/kotlin/io/github/kroune/cumobile/presentation/profile/ProfileScreen.kt
@@ -2,13 +2,17 @@
 
 package io.github.kroune.cumobile.presentation.profile
 
+import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.combinedClickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
@@ -20,21 +24,34 @@ import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.PlainTooltip
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
+import androidx.compose.material3.TooltipBox
+import androidx.compose.material3.TooltipDefaults
+import androidx.compose.material3.rememberTooltipState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.key
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.ImageBitmap
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalClipboardManager
+import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import androidx.compose.ui.window.Dialog
 import com.arkivanov.decompose.extensions.compose.subscribeAsState
 import io.github.kroune.cumobile.data.model.EmailInfo
 import io.github.kroune.cumobile.data.model.PhoneInfo
@@ -46,6 +63,7 @@ import io.github.kroune.cumobile.presentation.common.DetailTopBar
 import io.github.kroune.cumobile.presentation.common.ErrorContent
 import io.github.kroune.cumobile.presentation.common.LoadingContent
 import io.github.kroune.cumobile.presentation.common.rememberFilePicker
+import kotlinx.coroutines.launch
 
 /**
  * Profile screen displaying student info, avatar, and logout button.
@@ -152,14 +170,22 @@ private fun ProfileContent(
         Spacer(modifier = Modifier.height(24.dp))
 
         // Avatar section
+        var showAvatarDialog by remember { mutableStateOf(false) }
         AvatarSection(
             initials = state.initials,
-            hasAvatar = state.avatarBytes != null,
-            isDeleting = state.isDeletingAvatar,
-            isUploading = state.isUploadingAvatar,
+            avatarBitmap = state.avatarBitmap,
+            isBusy = state.isDeletingAvatar || state.isUploadingAvatar,
             onDelete = { onIntent(ProfileComponent.Intent.DeleteAvatar) },
             onUpload = { avatarPicker.launch() },
+            onAvatarClick = { showAvatarDialog = true },
         )
+
+        if (showAvatarDialog && state.avatarBitmap != null) {
+            AvatarFullScreenDialog(
+                avatarBitmap = state.avatarBitmap,
+                onDismiss = { showAvatarDialog = false },
+            )
+        }
 
         Spacer(modifier = Modifier.height(16.dp))
 
@@ -201,14 +227,14 @@ private fun ProfileContent(
 @Composable
 private fun AvatarSection(
     initials: String,
-    hasAvatar: Boolean,
-    isDeleting: Boolean,
-    isUploading: Boolean,
+    avatarBitmap: ImageBitmap?,
+    isBusy: Boolean,
     onDelete: () -> Unit,
     onUpload: () -> Unit,
+    onAvatarClick: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    val isBusy = isDeleting || isUploading
+    val hasAvatar = avatarBitmap != null
     Box(modifier = modifier, contentAlignment = Alignment.Center) {
         // Main avatar circle
         Box(
@@ -216,7 +242,8 @@ private fun AvatarSection(
                 .size(80.dp)
                 .clip(CircleShape)
                 .border(2.dp, AppTheme.colors.accent, CircleShape)
-                .background(AppTheme.colors.accent.copy(alpha = 0.2f), CircleShape),
+                .background(AppTheme.colors.accent.copy(alpha = 0.2f), CircleShape)
+                .clickable(enabled = avatarBitmap != null && !isBusy, onClick = onAvatarClick),
             contentAlignment = Alignment.Center,
         ) {
             if (isBusy) {
@@ -224,6 +251,13 @@ private fun AvatarSection(
                     modifier = Modifier.size(24.dp),
                     color = AppTheme.colors.accent,
                     strokeWidth = 2.dp,
+                )
+            } else if (avatarBitmap != null) {
+                Image(
+                    bitmap = avatarBitmap,
+                    contentDescription = "Аватар",
+                    contentScale = ContentScale.Crop,
+                    modifier = Modifier.fillMaxSize(),
                 )
             } else {
                 Text(
@@ -268,6 +302,33 @@ private fun AvatarSection(
 }
 
 @Composable
+private fun AvatarFullScreenDialog(
+    avatarBitmap: ImageBitmap?,
+    onDismiss: () -> Unit,
+) {
+    Dialog(onDismissRequest = onDismiss) {
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .aspectRatio(1f)
+                .clip(RoundedCornerShape(8.dp))
+                .background(Color.Black)
+                .clickable(onClick = onDismiss),
+            contentAlignment = Alignment.Center,
+        ) {
+            if (avatarBitmap != null) {
+                Image(
+                    bitmap = avatarBitmap,
+                    contentDescription = "Аватар",
+                    contentScale = ContentScale.Fit,
+                    modifier = Modifier.fillMaxSize(),
+                )
+            }
+        }
+    }
+}
+
+@Composable
 private fun InfoCard(
     state: ProfileComponent.State,
     modifier: Modifier = Modifier,
@@ -298,77 +359,143 @@ private fun InfoCard(
 
         // Other emails
         state.otherEmails.forEach { email ->
-            Spacer(modifier = Modifier.height(12.dp))
-            InfoRowWithBadge(
-                label = "Email",
-                value = maskEmail(email.value),
-                badge = email.type.ifEmpty { null },
-            )
+            key(email.value) {
+                Spacer(modifier = Modifier.height(12.dp))
+                InfoRowWithBadge(
+                    label = "Email",
+                    value = maskEmail(email.value),
+                    copyValue = email.value,
+                    badge = email.type.ifEmpty { null },
+                )
+            }
         }
 
         // Phones
         profile.phones.forEach { phone ->
-            Spacer(modifier = Modifier.height(12.dp))
-            InfoRowWithBadge(
-                label = "Телефон",
-                value = maskPhone(phone.value),
-                badge = phone.type.ifEmpty { null },
-            )
+            key(phone.value) {
+                Spacer(modifier = Modifier.height(12.dp))
+                InfoRowWithBadge(
+                    label = "Телефон",
+                    value = maskPhone(phone.value),
+                    copyValue = phone.value,
+                    badge = phone.type.ifEmpty { null },
+                )
+            }
         }
     }
 }
 
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 private fun InfoRow(
     label: String,
     value: String,
+    copyValue: String = value,
     modifier: Modifier = Modifier,
 ) {
-    Column(modifier = modifier.fillMaxWidth()) {
-        Text(
-            text = label,
-            color = AppTheme.colors.textSecondary,
-            fontSize = 12.sp,
-        )
-        Spacer(modifier = Modifier.height(2.dp))
-        Text(
-            text = value,
-            color = AppTheme.colors.textPrimary,
-            fontSize = 14.sp,
-        )
-    }
-}
+    @Suppress("DEPRECATION")
+    val clipboardManager = LocalClipboardManager.current
+    val tooltipState = rememberTooltipState()
+    val scope = rememberCoroutineScope()
 
-@Composable
-private fun InfoRowWithBadge(
-    label: String,
-    value: String,
-    badge: String?,
-    modifier: Modifier = Modifier,
-) {
-    Column(modifier = modifier.fillMaxWidth()) {
+    Column(
+        modifier = modifier
+            .fillMaxWidth()
+            .combinedClickable(
+                indication = null,
+                interactionSource = remember { MutableInteractionSource() },
+                onClick = {},
+                onLongClick = {
+                    clipboardManager.setText(AnnotatedString(copyValue))
+                    scope.launch { tooltipState.show() }
+                },
+            ),
+    ) {
         Text(
             text = label,
             color = AppTheme.colors.textSecondary,
             fontSize = 12.sp,
         )
         Spacer(modifier = Modifier.height(2.dp))
-        Row(verticalAlignment = Alignment.CenterVertically) {
+        TooltipBox(
+            positionProvider = TooltipDefaults.rememberTooltipPositionProvider(),
+            tooltip = {
+                PlainTooltip(
+                    containerColor = AppTheme.colors.textSecondary,
+                    contentColor = AppTheme.colors.background,
+                ) { Text("Скопировано") }
+            },
+            state = tooltipState,
+        ) {
             Text(
                 text = value,
                 color = AppTheme.colors.textPrimary,
                 fontSize = 14.sp,
             )
-            if (badge != null) {
-                Spacer(modifier = Modifier.width(8.dp))
+        }
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun InfoRowWithBadge(
+    label: String,
+    value: String,
+    badge: String?,
+    copyValue: String = value,
+    modifier: Modifier = Modifier,
+) {
+    @Suppress("DEPRECATION")
+    val clipboardManager = LocalClipboardManager.current
+    val tooltipState = rememberTooltipState()
+    val scope = rememberCoroutineScope()
+
+    Column(
+        modifier = modifier
+            .fillMaxWidth()
+            .combinedClickable(
+                indication = null,
+                interactionSource = remember { MutableInteractionSource() },
+                onClick = {},
+                onLongClick = {
+                    clipboardManager.setText(AnnotatedString(copyValue))
+                    scope.launch { tooltipState.show() }
+                },
+            ),
+    ) {
+        Text(
+            text = label,
+            color = AppTheme.colors.textSecondary,
+            fontSize = 12.sp,
+        )
+        Spacer(modifier = Modifier.height(2.dp))
+        TooltipBox(
+            positionProvider = TooltipDefaults.rememberTooltipPositionProvider(),
+            tooltip = {
+                PlainTooltip(
+                    containerColor = AppTheme.colors.textSecondary,
+                    contentColor = AppTheme.colors.background,
+                ) { Text("Скопировано") }
+            },
+            state = tooltipState,
+        ) {
+            Row(verticalAlignment = Alignment.CenterVertically) {
                 Text(
-                    text = badge,
-                    color = AppTheme.colors.textSecondary,
-                    fontSize = 11.sp,
-                    modifier = Modifier
-                        .background(AppTheme.colors.background, RoundedCornerShape(4.dp))
-                        .padding(horizontal = 6.dp, vertical = 2.dp),
+                    text = value,
+                    color = AppTheme.colors.textPrimary,
+                    fontSize = 14.sp,
                 )
+                if (badge != null) {
+                    Spacer(modifier = Modifier.width(8.dp))
+                    Text(
+                        text = badge,
+                        color = AppTheme.colors.textSecondary,
+                        fontSize = 11.sp,
+                        modifier = Modifier
+                            .background(AppTheme.colors.background, RoundedCornerShape(4.dp))
+                            .padding(horizontal = 6.dp, vertical = 2.dp),
+                    )
+                }
             }
         }
     }
@@ -376,7 +503,7 @@ private fun InfoRowWithBadge(
 
 /**
  * Masks an email address, showing the first 3 characters and domain.
- * Example: "john.doe@example.com" → "joh***@example.com"
+ * Example: "john.doe@example.com" -> "joh***@example.com"
  */
 internal fun maskEmail(email: String): String {
     val atIndex = email.indexOf('@')
@@ -388,7 +515,7 @@ internal fun maskEmail(email: String): String {
 
 /**
  * Masks a phone number, showing first 2 and last 2 digits.
- * Example: "+79001234567" → "+79*******67"
+ * Example: "+79001234567" -> "+79*******67"
  */
 internal fun maskPhone(phone: String): String {
     val digits = phone.filter { it.isDigit() }
@@ -497,30 +624,6 @@ private fun PreviewProfileLoadingLight() {
     CuMobileTheme(darkTheme = false) {
         ProfileScreenContent(
             state = ProfileComponent.State(isLoading = true),
-            onIntent = {},
-            onBack = {},
-        )
-    }
-}
-
-@Preview
-@Composable
-private fun PreviewProfileWithCalendarDark() {
-    CuMobileTheme(darkTheme = true) {
-        ProfileScreenContent(
-            state = previewProfileState.copy(),
-            onIntent = {},
-            onBack = {},
-        )
-    }
-}
-
-@Preview
-@Composable
-private fun PreviewProfileWithCalendarLight() {
-    CuMobileTheme(darkTheme = false) {
-        ProfileScreenContent(
-            state = previewProfileState.copy(),
             onIntent = {},
             onBack = {},
         )


### PR DESCRIPTION
## Summary
- **Avatar image now renders** — `avatarBytes` were fetched but never decoded/displayed; now uses `decodeImageBitmap()` + `Image()` composable in the avatar circle
- **Long-press to copy** on all info rows (login, telegram, email, phone) — copies the real (unmasked) value to clipboard with a brief "Скопировано" indicator
- Masked emails/phones still display masked, but copy the full original value

## Test plan
- [x] detektAll passes
- [x] verifyRoborazzi passes
- [x] Tested on physical device (OnePlus CPH2747, Android 16)
- [x] Avatar loads and displays correctly
- [x] Long-press on "Логин" copies value (confirmed via Android system clipboard toast)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Profile avatars now show as images (also appear in the app top bar and home).
  * Tap avatar to open a full-screen view; avatar clears after deletion and updates after upload.
  * Long-press contact items to copy their full value to clipboard with a transient “Copied” confirmation.
* **Style**
  * Removed preview artifacts for a cleaner build output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->