### PR TITLE
Add Android release signing

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -171,6 +171,44 @@ jobs:
           path: androidApp/build/outputs/apk/debug/*.apk
           if-no-files-found: error
 
+  release-build:
+    name: Build Release APK
+    needs: [ ktlint, detekt, unit-tests, roborazzi ]
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6.0.2
+
+      - name: Setup JDK ${{ env.JAVA_VERSION }}
+        uses: actions/setup-java@v5.2.0
+        with:
+          distribution: temurin
+          java-version: ${{ env.JAVA_VERSION }}
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v6.0.0
+        with:
+          cache-encryption-key: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
+
+      - name: Decode keystore
+        run: echo "${{ secrets.RELEASE_KEYSTORE_BASE64 }}" | base64 -d > androidApp/release.jks
+
+      - name: Assemble release APK
+        env:
+          RELEASE_STORE_FILE: release.jks
+          RELEASE_STORE_PASSWORD: ${{ secrets.RELEASE_STORE_PASSWORD }}
+          RELEASE_KEY_ALIAS: ${{ secrets.RELEASE_KEY_ALIAS }}
+          RELEASE_KEY_PASSWORD: ${{ secrets.RELEASE_KEY_PASSWORD }}
+        run: ./gradlew :androidApp:assembleRelease -s
+
+      - name: Upload release APK
+        uses: actions/upload-artifact@v7
+        with:
+          name: release-apk
+          path: androidApp/build/outputs/apk/release/*.apk
+          if-no-files-found: error
+
   ios:
     name: iOS Build
     needs: [ ktlint, detekt, unit-tests, roborazzi ]

--- a/androidApp/build.gradle.kts
+++ b/androidApp/build.gradle.kts
@@ -1,3 +1,5 @@
+import java.util.Properties
+
 plugins {
     alias(libs.plugins.androidApplication)
     alias(libs.plugins.composeCompiler)
@@ -11,12 +13,35 @@ val jdkVersion =
         .get()
         .toInt()
 
+val localProperties =
+    Properties().apply {
+        val file = rootProject.file("local.properties")
+        if (file.exists()) {
+            file.reader().use { load(it) }
+        }
+    }
+
+fun signingProperty(name: String): String? =
+    System.getenv(name) ?: localProperties.getProperty(name)
+
 android {
     namespace = "com.thirdparty.cumobile"
     compileSdk =
         libs.versions.android.max.sdk
             .get()
             .toInt()
+
+    signingConfigs {
+        create("release") {
+            val storeFilePath = signingProperty("RELEASE_STORE_FILE")
+            if (storeFilePath != null) {
+                storeFile = file(storeFilePath)
+                storePassword = signingProperty("RELEASE_STORE_PASSWORD")
+                keyAlias = signingProperty("RELEASE_KEY_ALIAS")
+                keyPassword = signingProperty("RELEASE_KEY_PASSWORD")
+            }
+        }
+    }
 
     defaultConfig {
         applicationId = "com.thirdparty.cumobile"
@@ -70,6 +95,7 @@ android {
         }
 
         release {
+            signingConfig = signingConfigs.getByName("release")
             isMinifyEnabled = true
             isShrinkResources = true
             proguardFiles(


### PR DESCRIPTION
## Summary
- Configure release signing in `androidApp/build.gradle.kts` (reads from `local.properties` or env vars)
- Add CI job to build signed release APK on pushes to `main`
- GitHub secrets already set: `RELEASE_KEYSTORE_BASE64`, `RELEASE_STORE_PASSWORD`, `RELEASE_KEY_ALIAS`, `RELEASE_KEY_PASSWORD`

## Test plan
- [x] `assembleRelease` builds locally
- [x] APK verified signed with `apksigner verify` (APK Signature Scheme v2)
- [x] ktlint and detekt pass
- [ ] CI release-build job succeeds after merge to main

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Chores
* Added automated release build process to CI/CD pipeline that executes on main branch after passing all validations and tests
* Implemented dynamic release signing configuration with environment variable credential support for secure builds

<!-- end of auto-generated comment: release notes by coderabbit.ai -->