### PR TITLE
Reduce release APK size from 11MB to 5.8MB and fix flaky screenshot t…

### DIFF
--- a/androidApp/proguard-rules.pro
+++ b/androidApp/proguard-rules.pro
@@ -1,21 +1,27 @@
-# Add project specific ProGuard rules here.
-# You can control the set of applied configuration files using the
-# proguardFiles setting in build.gradle.
-#
-# For more details, see
-#   http://developer.android.com/guide/developing/tools/proguard.html
+# Flatten all obfuscated classes into a single root package.
+# Reduces dex string table size (package name prefixes).
+-repackageclasses ''
 
-# If your project uses WebView with JS, uncomment the following
-# and specify the fully qualified class name to the JavaScript interface
-# class:
-#-keepclassmembers class fqcn.of.javascript.interface.for.webview {
-#   public *;
-#}
+# Strip Kotlin null-check intrinsics inserted at every non-null parameter boundary.
+# Trade-off: NPE instead of "Parameter X is null" IllegalArgumentException.
+-assumenosideeffects class kotlin.jvm.internal.Intrinsics {
+    public static void checkNotNull(...);
+    public static void checkNotNullParameter(...);
+    public static void checkParameterIsNotNull(...);
+    public static void checkNotNullExpressionValue(...);
+    public static void checkExpressionValueIsNotNull(...);
+    public static void checkReturnedValueIsNotNull(...);
+    public static void checkFieldIsNotNull(...);
+}
 
-# Uncomment this to preserve the line number information for
-# debugging stack traces.
-#-keepattributes SourceFile,LineNumberTable
+# Disable coroutines debug facilities in release: assertions, debug mode, stack trace recovery.
+-assumenosideeffects class kotlinx.coroutines.DebugKt {
+    boolean getASSERTIONS_ENABLED();
+    boolean getDEBUG();
+    boolean getRECOVER_STACK_TRACES();
+}
 
-# If you keep the line number information, uncomment this to
-# hide the original source file name.
-#-renamesourcefileattribute SourceFile
+# Main dispatcher is always present on Android.
+-assumenosideeffects class kotlinx.coroutines.internal.MainDispatchersKt {
+    boolean SUPPORT_MISSING;
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -72,7 +72,7 @@ androidx-datastore-preferences = { module = "androidx.datastore:datastore-prefer
 
 androidx-room-runtime = { module = "androidx.room:room-runtime", version.ref = "room" }
 androidx-room-compiler = { module = "androidx.room:room-compiler", version.ref = "room" }
-androidx-sqlite-bundled = { module = "androidx.sqlite:sqlite-bundled", version.ref = "sqlite" }
+androidx-sqlite-framework = { module = "androidx.sqlite:sqlite-framework", version.ref = "sqlite" }
 
 decompose = { group = "com.arkivanov.decompose", name = "decompose", version.ref = "decompose" }
 decompose-lifecycle = { group = "com.arkivanov.essenty", name = "lifecycle", version.ref = "essenty" }

--- a/shared/build.gradle.kts
+++ b/shared/build.gradle.kts
@@ -125,7 +125,7 @@ kotlin {
             implementation(libs.androidx.datastore.preferences)
 
             implementation(libs.androidx.room.runtime)
-            implementation(libs.androidx.sqlite.bundled)
+            implementation(libs.androidx.sqlite.framework)
 
             implementation(libs.kotlin.logging)
             implementation(libs.kotlinx.datetime)

--- a/shared/src/androidMain/kotlin/io/github/kroune/cumobile/di/AndroidKoin.kt
+++ b/shared/src/androidMain/kotlin/io/github/kroune/cumobile/di/AndroidKoin.kt
@@ -1,6 +1,7 @@
 package io.github.kroune.cumobile.di
 
 import android.content.Context
+import androidx.sqlite.driver.AndroidSQLiteDriver
 import io.github.kroune.cumobile.data.local.AndroidFileOpener
 import io.github.kroune.cumobile.data.local.AndroidFileStorage
 import io.github.kroune.cumobile.data.local.AndroidPdfGenerator
@@ -20,7 +21,7 @@ import org.koin.dsl.module
 fun initKoinAndroid(context: Context) {
     val platformModule = module {
         single { createDataStore { dataStorePath(context) } }
-        single { buildAppDatabase(getDatabaseBuilder(context)) }
+        single { buildAppDatabase(getDatabaseBuilder(context), AndroidSQLiteDriver()) }
         single<FileStorage> { AndroidFileStorage(context) }
         single<FileOpener> { AndroidFileOpener(context) }
         single<PdfGenerator> { AndroidPdfGenerator() }

--- a/shared/src/commonMain/kotlin/io/github/kroune/cumobile/data/local/db/DatabaseBuilder.kt
+++ b/shared/src/commonMain/kotlin/io/github/kroune/cumobile/data/local/db/DatabaseBuilder.kt
@@ -1,7 +1,7 @@
 package io.github.kroune.cumobile.data.local.db
 
 import androidx.room.RoomDatabase
-import androidx.sqlite.driver.bundled.BundledSQLiteDriver
+import androidx.sqlite.SQLiteDriver
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.IO
@@ -10,9 +10,10 @@ internal const val DatabaseFileName = "cumobile.db"
 
 fun buildAppDatabase(
     builder: RoomDatabase.Builder<AppDatabase>,
+    driver: SQLiteDriver,
     queryDispatcher: CoroutineDispatcher = Dispatchers.IO,
 ): AppDatabase =
     builder
-        .setDriver(BundledSQLiteDriver())
+        .setDriver(driver)
         .setQueryCoroutineContext(queryDispatcher)
         .build()

--- a/shared/src/commonMain/kotlin/io/github/kroune/cumobile/presentation/common/ui/TaskCard.kt
+++ b/shared/src/commonMain/kotlin/io/github/kroune/cumobile/presentation/common/ui/TaskCard.kt
@@ -105,7 +105,7 @@ private fun DeadlineDateRow(
     modifier: Modifier = Modifier,
 ) {
     val displayText = formatDeadline(deadline)
-    val overdue = isOverdue(deadline)
+    val overdue = isOverdue(deadline, LocalClock.current.now())
 
     Row(
         modifier = modifier.fillMaxWidth(),
@@ -174,7 +174,10 @@ private fun taskStateBadgeLabel(
  */
 private val timezoneOffsetRegex = Regex("[+-]\\d{2}:\\d{2}$")
 
-internal fun isOverdue(deadline: String?): Boolean {
+internal fun isOverdue(
+    deadline: String?,
+    now: kotlin.time.Instant,
+): Boolean {
     if (deadline == null) return false
     return try {
         var normalized = deadline.trim()
@@ -194,9 +197,7 @@ internal fun isOverdue(deadline: String?): Boolean {
         }
         val deadlineDateTime = LocalDateTime.parse(isoString)
         val deadlineInstant = deadlineDateTime.toInstant(TimeZone.currentSystemDefault())
-        val now = kotlin.time.Clock.System
-            .now()
-        deadlineInstant < now
+        deadlineInstant.toEpochMilliseconds() < now.toEpochMilliseconds()
     } catch (e: Exception) {
         logger.error(e) { "Failed to parse deadline for overdue check: $deadline" }
         false

--- a/shared/src/commonMain/kotlin/io/github/kroune/cumobile/presentation/common/ui/TaskCardPreviews.kt
+++ b/shared/src/commonMain/kotlin/io/github/kroune/cumobile/presentation/common/ui/TaskCardPreviews.kt
@@ -4,6 +4,7 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -31,8 +32,10 @@ private val previewTaskWithOffset = StudentTask(
 @Composable
 private fun PreviewDeadlineTaskCardDark() {
     CuMobileTheme(darkTheme = true) {
-        Box(Modifier.background(AppTheme.colors.background).padding(16.dp)) {
-            DeadlineTaskCard(task = previewTask, onClick = {})
+        CompositionLocalProvider(LocalClock provides previewClock) {
+            Box(Modifier.background(AppTheme.colors.background).padding(16.dp)) {
+                DeadlineTaskCard(task = previewTask, onClick = {})
+            }
         }
     }
 }
@@ -41,8 +44,10 @@ private fun PreviewDeadlineTaskCardDark() {
 @Composable
 private fun PreviewDeadlineTaskCardLight() {
     CuMobileTheme(darkTheme = false) {
-        Box(Modifier.background(AppTheme.colors.background).padding(16.dp)) {
-            DeadlineTaskCard(task = previewTask, onClick = {})
+        CompositionLocalProvider(LocalClock provides previewClock) {
+            Box(Modifier.background(AppTheme.colors.background).padding(16.dp)) {
+                DeadlineTaskCard(task = previewTask, onClick = {})
+            }
         }
     }
 }
@@ -51,8 +56,10 @@ private fun PreviewDeadlineTaskCardLight() {
 @Composable
 private fun PreviewDeadlineTaskCardWithOffsetDark() {
     CuMobileTheme(darkTheme = true) {
-        Box(Modifier.background(AppTheme.colors.background).padding(16.dp)) {
-            DeadlineTaskCard(task = previewTaskWithOffset, onClick = {})
+        CompositionLocalProvider(LocalClock provides previewClock) {
+            Box(Modifier.background(AppTheme.colors.background).padding(16.dp)) {
+                DeadlineTaskCard(task = previewTaskWithOffset, onClick = {})
+            }
         }
     }
 }
@@ -61,8 +68,10 @@ private fun PreviewDeadlineTaskCardWithOffsetDark() {
 @Composable
 private fun PreviewDeadlineTaskCardWithOffsetLight() {
     CuMobileTheme(darkTheme = false) {
-        Box(Modifier.background(AppTheme.colors.background).padding(16.dp)) {
-            DeadlineTaskCard(task = previewTaskWithOffset, onClick = {})
+        CompositionLocalProvider(LocalClock provides previewClock) {
+            Box(Modifier.background(AppTheme.colors.background).padding(16.dp)) {
+                DeadlineTaskCard(task = previewTaskWithOffset, onClick = {})
+            }
         }
     }
 }

--- a/shared/src/commonMain/kotlin/io/github/kroune/cumobile/presentation/common/ui/Theme.kt
+++ b/shared/src/commonMain/kotlin/io/github/kroune/cumobile/presentation/common/ui/Theme.kt
@@ -12,6 +12,8 @@ import androidx.compose.runtime.ReadOnlyComposable
 import androidx.compose.runtime.staticCompositionLocalOf
 import androidx.compose.ui.graphics.Color
 import io.github.kroune.cumobile.data.model.TaskState
+import kotlinx.datetime.TimeZone
+import kotlinx.datetime.toInstant
 
 /**
  * Complete color palette for the CuMobile app.
@@ -166,6 +168,25 @@ val LightAppColors = AppColorScheme(
 )
 
 val LocalAppColors = staticCompositionLocalOf { DarkAppColors }
+
+/**
+ * Overridable clock for composables that need "now" (e.g. overdue checks).
+ * Defaults to [kotlin.time.Clock.System]. Provide a fixed clock in previews/tests.
+ */
+val LocalClock = staticCompositionLocalOf<kotlin.time.Clock> { kotlin.time.Clock.System }
+
+/** Fixed clock for previews/tests: 2026-03-30T12:00:00Z — before all preview deadlines. */
+val previewClock: kotlin.time.Clock = object : kotlin.time.Clock {
+    private val fixedInstant = kotlin.time.Instant.fromEpochMilliseconds(
+        kotlinx.datetime
+            .LocalDateTime(2026, 3, 30, 12, 0, 0)
+            .toInstant(TimeZone.UTC)
+            .toEpochMilliseconds(),
+    )
+
+    override fun now(): kotlin.time.Instant =
+        fixedInstant
+}
 
 /** App-wide theme accessor. Use [AppTheme.colors] inside composables. */
 object AppTheme {

--- a/shared/src/commonMain/kotlin/io/github/kroune/cumobile/presentation/home/ui/HomeScreenPreviews.kt
+++ b/shared/src/commonMain/kotlin/io/github/kroune/cumobile/presentation/home/ui/HomeScreenPreviews.kt
@@ -4,6 +4,7 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
 import io.github.kroune.cumobile.data.model.ClassData
@@ -16,6 +17,8 @@ import io.github.kroune.cumobile.presentation.common.ContentState
 import io.github.kroune.cumobile.presentation.common.ui.AppTheme
 import io.github.kroune.cumobile.presentation.common.ui.CuMobileTheme
 import io.github.kroune.cumobile.presentation.common.ui.ErrorContent
+import io.github.kroune.cumobile.presentation.common.ui.LocalClock
+import io.github.kroune.cumobile.presentation.common.ui.previewClock
 import io.github.kroune.cumobile.presentation.home.HomeComponent
 import kotlinx.datetime.LocalDate
 
@@ -120,7 +123,9 @@ private fun PreviewHomeScreenSkeletonLight() {
 @Composable
 private fun PreviewHomeScreenDark() {
     CuMobileTheme(darkTheme = true) {
-        HomeContent(state = previewHomeState, onIntent = {}, onTaskClick = {}, onCourseClick = {})
+        CompositionLocalProvider(LocalClock provides previewClock) {
+            HomeContent(state = previewHomeState, onIntent = {}, onTaskClick = {}, onCourseClick = {})
+        }
     }
 }
 
@@ -128,7 +133,9 @@ private fun PreviewHomeScreenDark() {
 @Composable
 private fun PreviewHomeScreenLight() {
     CuMobileTheme(darkTheme = false) {
-        HomeContent(state = previewHomeState, onIntent = {}, onTaskClick = {}, onCourseClick = {})
+        CompositionLocalProvider(LocalClock provides previewClock) {
+            HomeContent(state = previewHomeState, onIntent = {}, onTaskClick = {}, onCourseClick = {})
+        }
     }
 }
 
@@ -178,12 +185,14 @@ private fun PreviewHomeScreenLoadingDark() {
 @Composable
 private fun PreviewHomeScreenEmptyDark() {
     CuMobileTheme(darkTheme = true) {
-        HomeContent(
-            state = previewHomeEmptyState,
-            onIntent = {},
-            onTaskClick = {},
-            onCourseClick = {},
-        )
+        CompositionLocalProvider(LocalClock provides previewClock) {
+            HomeContent(
+                state = previewHomeEmptyState,
+                onIntent = {},
+                onTaskClick = {},
+                onCourseClick = {},
+            )
+        }
     }
 }
 
@@ -191,12 +200,14 @@ private fun PreviewHomeScreenEmptyDark() {
 @Composable
 private fun PreviewHomeScreenEmptyLight() {
     CuMobileTheme(darkTheme = false) {
-        HomeContent(
-            state = previewHomeEmptyState,
-            onIntent = {},
-            onTaskClick = {},
-            onCourseClick = {},
-        )
+        CompositionLocalProvider(LocalClock provides previewClock) {
+            HomeContent(
+                state = previewHomeEmptyState,
+                onIntent = {},
+                onTaskClick = {},
+                onCourseClick = {},
+            )
+        }
     }
 }
 
@@ -204,11 +215,13 @@ private fun PreviewHomeScreenEmptyLight() {
 @Composable
 private fun PreviewHomeWithScheduleLight() {
     CuMobileTheme(darkTheme = false) {
-        HomeContent(
-            state = previewHomeWithScheduleState,
-            onIntent = {},
-            onTaskClick = {},
-            onCourseClick = {},
-        )
+        CompositionLocalProvider(LocalClock provides previewClock) {
+            HomeContent(
+                state = previewHomeWithScheduleState,
+                onIntent = {},
+                onTaskClick = {},
+                onCourseClick = {},
+            )
+        }
     }
 }

--- a/shared/src/commonMain/kotlin/io/github/kroune/cumobile/presentation/home/ui/ScheduleWidgets.kt
+++ b/shared/src/commonMain/kotlin/io/github/kroune/cumobile/presentation/home/ui/ScheduleWidgets.kt
@@ -18,6 +18,7 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -30,6 +31,8 @@ import androidx.compose.ui.unit.sp
 import io.github.kroune.cumobile.data.model.ClassData
 import io.github.kroune.cumobile.presentation.common.ui.AppTheme
 import io.github.kroune.cumobile.presentation.common.ui.CuMobileTheme
+import io.github.kroune.cumobile.presentation.common.ui.LocalClock
+import io.github.kroune.cumobile.presentation.common.ui.previewClock
 import kotlinx.datetime.DatePeriod
 import kotlinx.datetime.LocalDate
 import kotlinx.datetime.format.MonthNames
@@ -311,11 +314,13 @@ private fun generateWeekDays(weekStart: LocalDate): List<DayData> =
 @Composable
 private fun PreviewHomeWithScheduleDark() {
     CuMobileTheme(darkTheme = true) {
-        HomeContent(
-            state = previewHomeWithScheduleState,
-            onIntent = {},
-            onTaskClick = {},
-            onCourseClick = {},
-        )
+        CompositionLocalProvider(LocalClock provides previewClock) {
+            HomeContent(
+                state = previewHomeWithScheduleState,
+                onIntent = {},
+                onTaskClick = {},
+                onCourseClick = {},
+            )
+        }
     }
 }

--- a/shared/src/commonMain/kotlin/io/github/kroune/cumobile/presentation/tasks/ui/TaskListItem.kt
+++ b/shared/src/commonMain/kotlin/io/github/kroune/cumobile/presentation/tasks/ui/TaskListItem.kt
@@ -26,6 +26,7 @@ import androidx.compose.ui.unit.sp
 import io.github.kroune.cumobile.data.model.StudentTask
 import io.github.kroune.cumobile.presentation.common.formatDeadline
 import io.github.kroune.cumobile.presentation.common.ui.AppTheme
+import io.github.kroune.cumobile.presentation.common.ui.LocalClock
 import io.github.kroune.cumobile.presentation.common.ui.StatusBadge
 import io.github.kroune.cumobile.presentation.common.ui.isOverdue
 import io.github.kroune.cumobile.presentation.common.ui.stripEmojiPrefix
@@ -115,7 +116,7 @@ private fun DeadlineText(
 ) {
     val deadline = task.deadline ?: task.exercise.deadline
     if (deadline != null) {
-        val overdue = isOverdue(deadline)
+        val overdue = isOverdue(deadline, LocalClock.current.now())
         Row(
             modifier = modifier,
             verticalAlignment = Alignment.CenterVertically,

--- a/shared/src/commonMain/kotlin/io/github/kroune/cumobile/presentation/tasks/ui/TaskListItemPreviews.kt
+++ b/shared/src/commonMain/kotlin/io/github/kroune/cumobile/presentation/tasks/ui/TaskListItemPreviews.kt
@@ -4,6 +4,7 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -13,6 +14,8 @@ import io.github.kroune.cumobile.data.model.TaskExercise
 import io.github.kroune.cumobile.data.model.TaskState
 import io.github.kroune.cumobile.presentation.common.ui.AppTheme
 import io.github.kroune.cumobile.presentation.common.ui.CuMobileTheme
+import io.github.kroune.cumobile.presentation.common.ui.LocalClock
+import io.github.kroune.cumobile.presentation.common.ui.previewClock
 
 private val previewTask = StudentTask(
     state = TaskState.InProgress,
@@ -33,12 +36,14 @@ private val previewTaskWithOffset = StudentTask(
 @Composable
 private fun PreviewTaskListItemDark() {
     CuMobileTheme(darkTheme = true) {
-        Box(
-            Modifier
-                .background(AppTheme.colors.background)
-                .padding(16.dp),
-        ) {
-            TaskListItem(task = previewTask, onClick = {})
+        CompositionLocalProvider(LocalClock provides previewClock) {
+            Box(
+                Modifier
+                    .background(AppTheme.colors.background)
+                    .padding(16.dp),
+            ) {
+                TaskListItem(task = previewTask, onClick = {})
+            }
         }
     }
 }
@@ -47,12 +52,14 @@ private fun PreviewTaskListItemDark() {
 @Composable
 private fun PreviewTaskListItemLight() {
     CuMobileTheme(darkTheme = false) {
-        Box(
-            Modifier
-                .background(AppTheme.colors.background)
-                .padding(16.dp),
-        ) {
-            TaskListItem(task = previewTask, onClick = {})
+        CompositionLocalProvider(LocalClock provides previewClock) {
+            Box(
+                Modifier
+                    .background(AppTheme.colors.background)
+                    .padding(16.dp),
+            ) {
+                TaskListItem(task = previewTask, onClick = {})
+            }
         }
     }
 }
@@ -61,12 +68,14 @@ private fun PreviewTaskListItemLight() {
 @Composable
 private fun PreviewTaskListItemWithOffsetDark() {
     CuMobileTheme(darkTheme = true) {
-        Box(
-            Modifier
-                .background(AppTheme.colors.background)
-                .padding(16.dp),
-        ) {
-            TaskListItem(task = previewTaskWithOffset, onClick = {})
+        CompositionLocalProvider(LocalClock provides previewClock) {
+            Box(
+                Modifier
+                    .background(AppTheme.colors.background)
+                    .padding(16.dp),
+            ) {
+                TaskListItem(task = previewTaskWithOffset, onClick = {})
+            }
         }
     }
 }
@@ -75,12 +84,14 @@ private fun PreviewTaskListItemWithOffsetDark() {
 @Composable
 private fun PreviewTaskListItemWithOffsetLight() {
     CuMobileTheme(darkTheme = false) {
-        Box(
-            Modifier
-                .background(AppTheme.colors.background)
-                .padding(16.dp),
-        ) {
-            TaskListItem(task = previewTaskWithOffset, onClick = {})
+        CompositionLocalProvider(LocalClock provides previewClock) {
+            Box(
+                Modifier
+                    .background(AppTheme.colors.background)
+                    .padding(16.dp),
+            ) {
+                TaskListItem(task = previewTaskWithOffset, onClick = {})
+            }
         }
     }
 }

--- a/shared/src/commonMain/kotlin/io/github/kroune/cumobile/presentation/tasks/ui/TasksScreenPreviews.kt
+++ b/shared/src/commonMain/kotlin/io/github/kroune/cumobile/presentation/tasks/ui/TasksScreenPreviews.kt
@@ -1,12 +1,15 @@
 package io.github.kroune.cumobile.presentation.tasks.ui
 
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.tooling.preview.Preview
 import io.github.kroune.cumobile.data.model.StudentTask
 import io.github.kroune.cumobile.data.model.TaskCourse
 import io.github.kroune.cumobile.data.model.TaskExercise
 import io.github.kroune.cumobile.data.model.TaskState
 import io.github.kroune.cumobile.presentation.common.ui.CuMobileTheme
+import io.github.kroune.cumobile.presentation.common.ui.LocalClock
+import io.github.kroune.cumobile.presentation.common.ui.previewClock
 import io.github.kroune.cumobile.presentation.tasks.TasksComponent
 import io.github.kroune.cumobile.presentation.tasks.recomputeDerived
 import kotlinx.collections.immutable.persistentListOf
@@ -60,7 +63,9 @@ private val previewTasksArchiveState = TasksComponent
 @Composable
 private fun PreviewTasksScreenDark() {
     CuMobileTheme(darkTheme = true) {
-        TasksScreenContent(state = previewTasksState, onIntent = {})
+        CompositionLocalProvider(LocalClock provides previewClock) {
+            TasksScreenContent(state = previewTasksState, onIntent = {})
+        }
     }
 }
 
@@ -68,7 +73,9 @@ private fun PreviewTasksScreenDark() {
 @Composable
 private fun PreviewTasksScreenLight() {
     CuMobileTheme(darkTheme = false) {
-        TasksScreenContent(state = previewTasksState, onIntent = {})
+        CompositionLocalProvider(LocalClock provides previewClock) {
+            TasksScreenContent(state = previewTasksState, onIntent = {})
+        }
     }
 }
 
@@ -109,13 +116,15 @@ private fun PreviewTasksErrorLight() {
 @Composable
 private fun PreviewTasksEmptyFiltersDark() {
     CuMobileTheme(darkTheme = true) {
-        TasksScreenContent(
-            state = previewTasksState
-                .copy(
-                    searchQuery = "несуществующий запрос",
-                ).recomputeDerived(),
-            onIntent = {},
-        )
+        CompositionLocalProvider(LocalClock provides previewClock) {
+            TasksScreenContent(
+                state = previewTasksState
+                    .copy(
+                        searchQuery = "несуществующий запрос",
+                    ).recomputeDerived(),
+                onIntent = {},
+            )
+        }
     }
 }
 
@@ -131,13 +140,15 @@ private fun PreviewTasksArchiveDark() {
 @Composable
 private fun PreviewTasksWithFiltersDark() {
     CuMobileTheme(darkTheme = true) {
-        TasksScreenContent(
-            state = previewTasksState
-                .copy(
-                    statusFilter = TaskState.InProgress,
-                    courseFilter = "1",
-                ).recomputeDerived(),
-            onIntent = {},
-        )
+        CompositionLocalProvider(LocalClock provides previewClock) {
+            TasksScreenContent(
+                state = previewTasksState
+                    .copy(
+                        statusFilter = TaskState.InProgress,
+                        courseFilter = "1",
+                    ).recomputeDerived(),
+                onIntent = {},
+            )
+        }
     }
 }

--- a/shared/src/iosMain/kotlin/io/github/kroune/cumobile/di/IosKoin.kt
+++ b/shared/src/iosMain/kotlin/io/github/kroune/cumobile/di/IosKoin.kt
@@ -1,5 +1,6 @@
 package io.github.kroune.cumobile.di
 
+import androidx.sqlite.driver.NativeSQLiteDriver
 import io.github.kroune.cumobile.data.local.FileOpener
 import io.github.kroune.cumobile.data.local.FileStorage
 import io.github.kroune.cumobile.data.local.IosFileOpener
@@ -20,7 +21,7 @@ import org.koin.dsl.module
 fun iosKoinModule(): Module =
     module {
         single { createDataStore { dataStorePath() } }
-        single { buildAppDatabase(getDatabaseBuilder()) }
+        single { buildAppDatabase(getDatabaseBuilder(), NativeSQLiteDriver()) }
         single<FileStorage> { IosFileStorage() }
         single<FileOpener> { IosFileOpener() }
         single<PdfGenerator> { IosPdfGenerator() }


### PR DESCRIPTION
      ## Summary
      - Switch from `sqlite-bundled` to `sqlite-framework` — use system SQLite instead of bundling native `.so` for 4 architectures (**-4.3 MB**)
      - Add R8 rules: `repackageclasses`, strip Kotlin Intrinsics null checks, disable coroutines debug facilities in release (**-90 KB**)
      - Fix flaky screenshot tests by adding `LocalClock` CompositionLocal with `previewClock` — overdue checks in previews no longer depend on real time

      ## Test plan
      - [x] Release APK builds successfully (11 MB → 5.8 MB verified)
      - [x] All 148 roborazzi screenshot tests pass
      - [x] Compiles for both Android and iOS
      - [x] ktlint + detekt pass

      🤖 Generated with [Claude Code](https://claude.com/claude-code)